### PR TITLE
Description Field to Actions

### DIFF
--- a/src/classes/Action.ts
+++ b/src/classes/Action.ts
@@ -15,6 +15,7 @@ interface IActionData {
   trigger?: string
   terse?: string
   detail: string
+  description?: string
   pilot?: boolean
   mech?: boolean
   damage?: IDamageData[]
@@ -115,6 +116,7 @@ class Action {
   public readonly Activation: ActivationType
   public readonly Terse: string
   public readonly Detail: string
+  public readonly Description: string
   public readonly Cost: number
   public readonly HeatCost: number
   public readonly Frequency: Frequency
@@ -155,6 +157,7 @@ class Action {
     this.Activation = data.activation || ActivationType.Quick
     this.Terse = data.terse || ''
     this.Detail = data.detail || ''
+    this.Description = data.description || ''
     this.Cost = data.cost || 1
     this.HeatCost = heat && isNumber(heat) ? heat : 0
     // heat cost override
@@ -279,6 +282,7 @@ class Action {
       trigger: action.Trigger,
       terse: action.Terse,
       detail: action.Detail,
+      description: action.Description,
       pilot: action.IsPilotAction,
       mech: action.IsMechAction,
       damage: action.Damage ? action.Damage.map(x => Damage.Serialize(x)) : null,

--- a/src/ui/components/cards/_EquipmentCardBase.vue
+++ b/src/ui/components/cards/_EquipmentCardBase.vue
@@ -22,7 +22,7 @@
       <div class="overline ml-n2 subtle--text">EQUIPMENT ACTIONS</div>
       <v-row no-gutters justify="center">
         <v-col v-for="(a, i) in item.Actions" :key="`${item.Name}_action_${i}`" cols="auto">
-          <cc-action :action="a" :panel="$vuetify.breakpoint.lgAndUp" class="ma-2" />
+          <cc-action :action="a" :panel="$vuetify.breakpoint.lgAndUp" :displayDescription="true" class="ma-2" />
         </v-col>
       </v-row>
     </div>

--- a/src/ui/components/items/features/actions/CCAction.vue
+++ b/src/ui/components/items/features/actions/CCAction.vue
@@ -6,6 +6,7 @@
     :activations="activations"
     :unusable="unusable"
     :disabled="disabled"
+    :displayDescription="displayDescription"
     @use="$emit('use', $event)"
     @undo="$emit('undo')"
   />
@@ -25,6 +26,10 @@ export default Vue.extend({
     action: {
       type: Object,
       required: true,
+    },
+    displayDescription: {
+      type: Boolean,
+      required: false,
     },
     hover: { type: Boolean },
     popup: {

--- a/src/ui/components/items/features/actions/_actionBase.vue
+++ b/src/ui/components/items/features/actions/_actionBase.vue
@@ -24,7 +24,7 @@
       <div class="subtle--text overline mb-n2">Effect</div>
       <div v-html-safe="action.Detail" class="body-text stark--text" />
     </div>
-    <div v-if="action.Description">
+    <div v-if="action.Description && displayDescription">
       <div class="subtle--text overline mb-n2">Compendium Entry</div>
       <div v-html-safe="action.Description" class="body-text stark--text" />
     </div>
@@ -39,6 +39,11 @@ export default Vue.extend({
     action: {
       type: Object,
       required: true,
+    },
+    displayDescription: {
+      type: Boolean,
+      required: false,
+      default: false,
     },
   },
 })

--- a/src/ui/components/items/features/actions/_actionBase.vue
+++ b/src/ui/components/items/features/actions/_actionBase.vue
@@ -26,7 +26,7 @@
     </div>
     <div v-if="action.Description && displayDescription">
       <div class="subtle--text overline mb-n2">Compendium Entry</div>
-      <div v-html-safe="action.Description" class="body-text stark--text" />
+      <div v-html-safe="action.Description" class="flavor-text" />
     </div>
   </v-card-text>
 </template>

--- a/src/ui/components/items/features/actions/_actionBase.vue
+++ b/src/ui/components/items/features/actions/_actionBase.vue
@@ -24,6 +24,10 @@
       <div class="subtle--text overline mb-n2">Effect</div>
       <div v-html-safe="action.Detail" class="body-text stark--text" />
     </div>
+    <div v-if="action.Description">
+      <div class="subtle--text overline mb-n2">Compendium Entry</div>
+      <div v-html-safe="action.Description" class="body-text stark--text" />
+    </div>
   </v-card-text>
 </template>
 

--- a/src/ui/components/items/features/actions/_actionPanel.vue
+++ b/src/ui/components/items/features/actions/_actionPanel.vue
@@ -31,7 +31,7 @@
         </v-chip>
       </v-col>
     </v-row>
-    <action-base :action="action" class="mt-n6 mb-n2" />
+    <action-base :action="action" :displayDescription="displayDescription" class="mt-n6 mb-n2" />
   </v-alert>
 </template>
 
@@ -46,6 +46,11 @@ export default Vue.extend({
     action: {
       type: Object,
       required: true,
+    },
+    displayDescription: {
+      type: Boolean,
+      required: false,
+      default: false,
     },
   },
 })

--- a/src/ui/components/items/features/actions/_actionPopup.vue
+++ b/src/ui/components/items/features/actions/_actionPopup.vue
@@ -18,7 +18,7 @@
       {{ action.Frequency.ToString() }}
     </v-chip>
 
-    <action-base :action="action" />
+    <action-base :action="action" :displayDescription="true" />
   </cc-dialog>
 </template>
 
@@ -33,6 +33,11 @@ export default Vue.extend({
     action: {
       type: Object,
       required: true,
+    },
+    displayDescription: {
+      type: Boolean,
+      required: false,
+      default: true,
     },
   },
 })


### PR DESCRIPTION
# Description
Flavor text field added to actions.
The visibility is optional and can be controlled by `displayDescription` prop in `_actionBase.vue` and components that call `_actionBase.vue` directly or indirectly.

## Issue Number
[`#2444`](https://github.com/massif-press/compcon/issues/2444)

## Type of change
- [ ] New feature (non-breaking change which adds functionality)