### PR TITLE
Obvious buttons

### DIFF
--- a/src/features/encounters/npc/NpcCard.vue
+++ b/src/features/encounters/npc/NpcCard.vue
@@ -16,7 +16,7 @@
             </cc-short-string-editor>
           </div>
           <div class="flavor-text mt-n6 ml-2">
-            <cc-short-string-editor large :placeholder="npc.Subtitle" @set="npc.Subtitle = $event">
+            <cc-short-string-editor boxModel="mt-n3 ml-2" :placeholder="npc.Subtitle" @set="npc.Subtitle = $event">
               <b v-if="npc.Subtitle" class="heading-block stark--text" v-html="npc.Subtitle" />
               <i v-else class="heading-block subtle--text" v-html="'Add GM Summary'" />
             </cc-short-string-editor>

--- a/src/features/pilot_management/New/pages/IdentificationPage.vue
+++ b/src/features/pilot_management/New/pages/IdentificationPage.vue
@@ -50,7 +50,7 @@
         >
           <template v-slot:prepend>
             <cc-tooltip simple content="Generate Random Name">
-              <v-btn tonal small color="accent" class="ml-2 my-n2">
+              <v-btn small outlined color="secondary" class="fadeSelect my-n2">
                 <v-icon color="light" @click="randomName()">mdi-dice-multiple</v-icon>
               </v-btn>
             </cc-tooltip>
@@ -67,7 +67,7 @@
         <v-text-field v-model="pilot.Callsign" outlined label="Callsign" hide-details class="my-1">
           <template v-slot:prepend>
             <cc-tooltip simple content="Generate Random Callsign">
-              <v-btn tonal small color="accent" class="ml-2 my-n2">
+              <v-btn small outlined color="secondary" class="fadeSelect my-n2">
                 <v-icon color="light" @click="randomCallsign()">mdi-dice-multiple</v-icon>
               </v-btn>
             </cc-tooltip>
@@ -90,7 +90,7 @@
         >
           <template v-slot:prepend>
             <cc-tooltip simple content="Select Predefined Background">
-              <cc-background-selector @select="$emit('set', { attr: 'Background', val: $event })" />
+              <cc-background-selector small @select="$emit('set', { attr: 'Background', val: $event })" />
             </cc-tooltip>
           </template>
           <template v-slot:append-outer>

--- a/src/features/pilot_management/New/pages/IdentificationPage.vue
+++ b/src/features/pilot_management/New/pages/IdentificationPage.vue
@@ -50,7 +50,9 @@
         >
           <template v-slot:prepend>
             <cc-tooltip simple content="Generate Random Name">
-              <v-icon color="secondary" @click="randomName()">mdi-dice-multiple</v-icon>
+              <v-btn tonal small color="accent" class="ml-2 my-n2">
+                <v-icon color="light" @click="randomName()">mdi-dice-multiple</v-icon>
+              </v-btn>
             </cc-tooltip>
           </template>
           <template v-slot:append-outer>
@@ -65,7 +67,9 @@
         <v-text-field v-model="pilot.Callsign" outlined label="Callsign" hide-details class="my-1">
           <template v-slot:prepend>
             <cc-tooltip simple content="Generate Random Callsign">
-              <v-icon color="secondary" @click="randomCallsign()">mdi-dice-multiple</v-icon>
+              <v-btn tonal small color="accent" class="ml-2 my-n2">
+                <v-icon color="light" @click="randomCallsign()">mdi-dice-multiple</v-icon>
+              </v-btn>
             </cc-tooltip>
           </template>
           <template v-slot:append-outer>

--- a/src/features/pilot_management/PilotSheet/components/PilotHeader.vue
+++ b/src/features/pilot_management/PilotSheet/components/PilotHeader.vue
@@ -82,9 +82,11 @@
                   bottom
                   content="Edit License Level"
                 >
-                  <v-icon small dark class="fadeSelect" @click="$refs.levelEdit.show()">
+                <v-btn x-small outlined color="grey lighten-3" class="fadeSelect" @click="$refs.levelEdit.show()">
+                  <v-icon small>
                     mdi-circle-edit-outline
                   </v-icon>
+                </v-btn>
                 </cc-tooltip>
               </div>
               <div class="heading h1 mb-n4 py-1" style="font-size: 75px">
@@ -151,7 +153,10 @@
               <div class="stat-text white--text mt-n2 mb-n1">
                 <v-dialog max-width="1200px">
                   <template v-slot:activator="{ on }">
-                    <v-icon dark class="fadeSelect" v-on="on">mdi-card-bulleted-outline</v-icon>
+                    <v-btn x-small outlined color="grey lighten-3" class="fadeSelect" v-on="on">
+                      <v-icon>mdi-card-bulleted-outline</v-icon>
+                      IDENT Record
+                    </v-btn>
                   </template>
                   <v-sheet class="transparent">
                     <pilot-registration-card :pilot="pilot" pilot-ready />

--- a/src/features/pilot_management/PilotSheet/sections/components/SectionEditChip.vue
+++ b/src/features/pilot_management/PilotSheet/sections/components/SectionEditChip.vue
@@ -3,10 +3,11 @@
     <cc-tooltip inline simple :content="label">
       <v-chip
         small
+        outlined
         label
         dark
         :class="{ fadeSelect: !highlight }"
-        :color="highlight ? 'warning' : 'pilot'"
+        :color="highlight ? 'warning' : 'grey lighten-3'"
         style="margin-bottom: 1px"
         @click="$emit('open-selector')"
       >

--- a/src/features/pilot_management/PilotSheet/sections/components/SectionEditIcon.vue
+++ b/src/features/pilot_management/PilotSheet/sections/components/SectionEditIcon.vue
@@ -1,11 +1,16 @@
 <template>
   <span>
     <cc-tooltip inline simple :content="label">
-      <v-icon
-        dark
-        class="fadeSelect ml-8 mr-2"
+      <v-chip
+        outlined
+        small
+        label
+        color="grey lighten-3"
+        class="fadeSelect ml-8 mr-2 mb-1"
         @click="$emit('open-selector')"
-      >mdi-circle-edit-outline</v-icon>
+      >
+        <v-icon>mdi-circle-edit-outline</v-icon>
+      </v-chip>
     </cc-tooltip>
   </span>
 </template>

--- a/src/features/pilot_management/PilotSheet/sections/info/components/IdentBlock.vue
+++ b/src/features/pilot_management/PilotSheet/sections/info/components/IdentBlock.vue
@@ -9,7 +9,9 @@
       </v-col>
       <v-col cols="6" md="4" xl="3">
         <div class="overline mb-n3 subtle--text">NAME</div>
-        <cc-short-string-editor @set="pilot.Name = $event">{{ pilot.Name }}</cc-short-string-editor>
+        <cc-short-string-editor @set="pilot.Name = $event">
+          {{ pilot.Name }}
+        </cc-short-string-editor>
       </v-col>
       <v-col cols="6" md="4" xl="3">
         <div class="overline mb-n3 subtle--text">BACKGROUND</div>

--- a/src/features/pilot_management/PilotSheet/sections/info/components/IdentBlock.vue
+++ b/src/features/pilot_management/PilotSheet/sections/info/components/IdentBlock.vue
@@ -19,8 +19,8 @@
         <span>
           <cc-background-selector
             :pilot="pilot"
-            small
-            class="d-inline fadeSelect ml-n1"
+            dossier
+            class="d-inline"
             @select="pilot.Background = $event"
           />
         </span>

--- a/src/features/pilot_management/PilotSheet/sections/mech/index.vue
+++ b/src/features/pilot_management/PilotSheet/sections/mech/index.vue
@@ -9,7 +9,7 @@
     />
     <v-row no-gutters>
       <v-col cols="auto">
-        <cc-short-string-editor large before @set="mech.Name = $event">
+        <cc-short-string-editor playerMech color="light" @set="mech.Name = $event">
           <cc-title
             :small="small"
             :large="!small && mech.Name.length < 31"

--- a/src/features/pilot_management/PilotSheet/sections/mech/index.vue
+++ b/src/features/pilot_management/PilotSheet/sections/mech/index.vue
@@ -14,9 +14,9 @@
             :small="small"
             :large="!small && mech.Name.length < 31"
             :color="color"
-            class="px-3 ml-n6"
+            class="pl-12"
           >
-            {{ mech.Name }}&emsp;
+            &nbsp;{{ mech.Name }}&emsp;
           </cc-title>
         </cc-short-string-editor>
         <div :class="`mt-n${small ? '3' : '6'}`">

--- a/src/ui/components/CCComboSelect.vue
+++ b/src/ui/components/CCComboSelect.vue
@@ -1,7 +1,9 @@
 <template>
   <v-menu v-model="menu" offset-y :close-on-content-click="false">
     <template v-slot:activator="{ on }">
-      <v-icon small class="fadeSelect" v-on="on">mdi-circle-edit-outline</v-icon>
+      <v-btn outlined x-small class="fadeSelect ml-2" v-on="on">
+        <v-icon small>mdi-circle-edit-outline</v-icon>
+      </v-btn>
     </template>
     <v-card outlined>
       <v-card-text>

--- a/src/ui/components/CCShortStringEditor.vue
+++ b/src/ui/components/CCShortStringEditor.vue
@@ -2,9 +2,11 @@
   <v-fade-transition leave-absolute>
     <div v-if="!editing" key="str" :class="{ 'd-inline': inline }">
       <slot />
-      <v-icon :dark="before" small :class="`fadeSelect ${before ? 'mt-n12' : ''}`" @click="edit()">
-        mdi-circle-edit-outline
-      </v-icon>
+      <v-btn x-small outlined class="fadeSelect" @click="edit()">
+        <v-icon :dark="before" small :class="`${before ? 'mt-n12' : ''}`">
+          mdi-circle-edit-outline
+        </v-icon>
+      </v-btn>
     </div>
     <div v-else key="editname" :class="{ 'd-inline': inline }">
       <v-text-field

--- a/src/ui/components/CCShortStringEditor.vue
+++ b/src/ui/components/CCShortStringEditor.vue
@@ -2,7 +2,7 @@
   <v-fade-transition leave-absolute>
     <div v-if="!editing" key="str" :class="{ 'd-inline': inline }">
       <slot />
-      <v-btn outlined :x-small="!large" :color="color" :class="`fadeSelect ${boxModel} ${before ? 'before' : ''} ${large?'mt-n10':''}`" @click="edit()">
+      <v-btn outlined :x-small="!large&!playerMech" :color="color" :class="`fadeSelect ${boxModel} ${playerMech ? 'playerMech' : ''} ${large?'mt-n10':''}`" @click="edit()">
         <v-icon :small="!large">
           mdi-circle-edit-outline
         </v-icon>
@@ -42,7 +42,7 @@ export default class CCShortStringEditor extends Vue {
   @Prop({ type: Boolean })
   readonly large?: boolean
   @Prop({ type: Boolean })
-  readonly before?: boolean
+  readonly playerMech?: boolean
 
   newStr = ''
   editing = false
@@ -88,7 +88,7 @@ export default class CCShortStringEditor extends Vue {
   font-size: 1em;
   font-weight: bold;
 }
-.before {
+.playerMech {
   margin-top: -6rem;
 }
 </style>

--- a/src/ui/components/CCShortStringEditor.vue
+++ b/src/ui/components/CCShortStringEditor.vue
@@ -2,8 +2,8 @@
   <v-fade-transition leave-absolute>
     <div v-if="!editing" key="str" :class="{ 'd-inline': inline }">
       <slot />
-      <v-btn :size="large?'large':'x-small'" outlined :color="large?'white':''" :class="`fadeSelect ${before ? 'before' : ''}`" @click="edit()">
-        <v-icon small >
+      <v-btn outlined :x-small="!large" :color="color" :class="`fadeSelect ${before ? 'before' : ''} ${large?'mt-n10':''} ${boxModel}`" @click="edit()">
+        <v-icon :small="!large">
           mdi-circle-edit-outline
         </v-icon>
       </v-btn>

--- a/src/ui/components/CCShortStringEditor.vue
+++ b/src/ui/components/CCShortStringEditor.vue
@@ -33,6 +33,10 @@ import { Vue, Component, Prop } from 'vue-property-decorator'
 export default class CCShortStringEditor extends Vue {
   @Prop({ type: String, required: false })
   readonly placeholder?: string
+  @Prop({ type: String, required: false, default: '' })
+  color?: string
+  @Prop({ type: String, required: false, default: '' })
+  boxModel?: string
   @Prop({ type: Boolean, required: false })
   readonly inline?: boolean
   @Prop({ type: Boolean })

--- a/src/ui/components/CCShortStringEditor.vue
+++ b/src/ui/components/CCShortStringEditor.vue
@@ -2,8 +2,8 @@
   <v-fade-transition leave-absolute>
     <div v-if="!editing" key="str" :class="{ 'd-inline': inline }">
       <slot />
-      <v-btn x-small outlined class="fadeSelect" @click="edit()">
-        <v-icon :dark="before" small :class="`${before ? 'mt-n12' : ''}`">
+      <v-btn :size="large?'large':'x-small'" outlined :color="large?'white':''" :class="`fadeSelect ${before ? 'before' : ''}`" @click="edit()">
+        <v-icon small >
           mdi-circle-edit-outline
         </v-icon>
       </v-btn>
@@ -83,6 +83,9 @@ export default class CCShortStringEditor extends Vue {
 .label {
   font-size: 1em;
   font-weight: bold;
+}
+.before {
+  margin-top: -6rem;
 }
 </style>
 

--- a/src/ui/components/CCShortStringEditor.vue
+++ b/src/ui/components/CCShortStringEditor.vue
@@ -2,7 +2,7 @@
   <v-fade-transition leave-absolute>
     <div v-if="!editing" key="str" :class="{ 'd-inline': inline }">
       <slot />
-      <v-btn outlined :x-small="!large" :color="color" :class="`fadeSelect ${before ? 'before' : ''} ${large?'mt-n10':''} ${boxModel}`" @click="edit()">
+      <v-btn outlined :x-small="!large" :color="color" :class="`fadeSelect ${boxModel} ${before ? 'before' : ''} ${large?'mt-n10':''}`" @click="edit()">
         <v-icon :small="!large">
           mdi-circle-edit-outline
         </v-icon>

--- a/src/ui/components/selectors/CCBackgroundSelector.vue
+++ b/src/ui/components/selectors/CCBackgroundSelector.vue
@@ -1,6 +1,8 @@
 <template>
   <div>
-    <v-icon :small="small" color="secondary" @click="open()">cci-orbit</v-icon>
+    <v-btn small tonal color="accent" class="ml-2 my-n2" @click="open()">
+      <v-icon :small="small" color="light">cci-orbit</v-icon>
+    </v-btn>
     <cc-solo-dialog ref="dialog" fullscreen no-confirm title="Select Pilot Background">
       <cc-sidebar-view>
         <v-list-item

--- a/src/ui/components/selectors/CCBackgroundSelector.vue
+++ b/src/ui/components/selectors/CCBackgroundSelector.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
-    <v-btn small tonal color="accent" class="ml-2 my-n2" @click="open()">
-      <v-icon :small="small" color="light">cci-orbit</v-icon>
+    <v-btn :small="small" :x-small="dossier" outlined :color="dossier?'dark':'secondary'" class="fadeSelect my-n2" @click="open()">
+      <v-icon :small="dossier">cci-orbit</v-icon>
     </v-btn>
     <cc-solo-dialog ref="dialog" fullscreen no-confirm title="Select Pilot Background">
       <cc-sidebar-view>
@@ -56,6 +56,12 @@ export default Vue.extend({
     small: {
       type: Boolean,
       required: false,
+      default: false,
+    },
+    dossier: { // set this to true when using in IdentBlock.vue
+      type: Boolean,
+      required: false,
+      default: false,
     },
   },
   data: () => ({


### PR DESCRIPTION
Making buttons' appearances more clear that they are buttons, so new users can check it out without someone telling them about it.
Primarily, this means adding outlines on a bunch of buttons, particularly for player side content. GM-side content is actually pretty good about clarity, with where the edit buttons are located.

To do:
* [x] Check if they look good in all three base themes (GMS, HORUS, MSMC)
* [x] Ensure all player-side buttons are changed
* [ ] Any forward compatibility concerns??